### PR TITLE
Adding Azure Infrastructure

### DIFF
--- a/azure/parameters.json
+++ b/azure/parameters.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appServicePlanName": {
+            "value": ""
+        },
+        "appServiceName": {
+            "value": ""
+        },
+        "appServicePlanRG": {
+            "value": ""
+        },
+        "runtimeStack": {
+            "value": ""
+        },
+        "customHostName": {
+            "value": ""
+        },
+        "certificateResourceGroup": {
+            "value": ""
+        },
+        "certificateName": {
+            "value": ""
+        }
+    }
+}

--- a/azure/template.json
+++ b/azure/template.json
@@ -1,0 +1,75 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appServiceName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the App Service"
+            }
+        },
+        "appServicePlanName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the App Service Plan"
+            }
+        },
+        "appServicePlanRG": {
+            "type": "string",
+            "metadata": {
+                "description": "Resource Group where the ASP lives"
+            }
+        },
+        "runtimeStack": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the runtime stack for the container"
+            }
+        },
+        "customHostName": {
+            "type": "string",
+            "defaultValue": ""
+        },
+        "certificateResourceGroup": {
+            "type": "string"
+        },
+        "certificateName": {
+            "type": "string"
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "apiVersion": "2017-05-10",
+            "name": "[parameters('appServiceName')]",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "https://raw.githubusercontent.com/DFE-Digital/login.dfe.infrastructure/master/Shared/app-service.json",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "appServiceName": {
+                        "value": "[parameters('appServiceName')]"
+                    },
+                    "appServicePlanName": {
+                        "value": "[parameters('appServicePlanName')]"
+                    },
+                    "appServicePlanRG": {
+                        "value": "[parameters('appServicePlanRG')]"
+                    },
+                    "runtimeStack": {
+                        "value": "[parameters('runtimeStack')]"
+                    },
+                    "customHostName": {
+                        "value": "[parameters('customHostName')]"
+                    },
+                    "certificateThumbprint": {
+                        "value": "[reference(resourceId(parameters('certificateResourceGroup'), 'Microsoft.Web/certificates', parameters('certificateName')), '2016-03-01').Thumbprint]"
+                    }
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Moving away from the shared template to enable custom host names. Shared template still used as the reference