### PR TITLE
[DSI-6639] Revert healthcheck library to v3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "login.dfe.audit.transporter": "^3.0.0",
         "login.dfe.config.schema.common": "git+https://github.com/DFE-Digital/login.dfe.config.schema.common.git#v2.1.3",
         "login.dfe.express-error-handling": "git+https://github.com/DFE-Digital/login.dfe.express-error-handling.git#v3.0.0",
-        "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v4.0.0",
+        "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v3.0.0",
         "login.dfe.sanitization": "git+https://github.com/DFE-Digital/login.dfe.sanitization.git#v3.0.0",
         "login.dfe.service-notifications.jobs.client": "git+https://github.com/DFE-Digital/login.dfe.service-notifications.jobs.client.git#v2.0.0",
         "login.dfe.winston-appinsights": "git+https://github.com/DFE-Digital/login.dfe.winston-appinsights.git#v5.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "settings='./config/login.dfe.access.dev.json' node src/index.js",
     "dev:container": "nodemon src/index.js",
-    "test": "./node_modules/.bin/jest",
+    "test": "jest --coverage",
     "test:watch": "./node_modules/.bin/jest --watch"
   },
   "engines": {
@@ -31,7 +31,7 @@
     "login.dfe.audit.transporter": "^3.0.0",
     "login.dfe.config.schema.common": "git+https://github.com/DFE-Digital/login.dfe.config.schema.common.git#v2.1.3",
     "login.dfe.express-error-handling": "git+https://github.com/DFE-Digital/login.dfe.express-error-handling.git#v3.0.0",
-    "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v4.0.0",
+    "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v3.0.0",
     "login.dfe.sanitization": "git+https://github.com/DFE-Digital/login.dfe.sanitization.git#v3.0.0",
     "login.dfe.service-notifications.jobs.client": "git+https://github.com/DFE-Digital/login.dfe.service-notifications.jobs.client.git#v2.0.0",
     "login.dfe.winston-appinsights": "git+https://github.com/DFE-Digital/login.dfe.winston-appinsights.git#v5.0.0",


### PR DESCRIPTION
**Jira** ticket https://dfe-secureaccess.atlassian.net/browse/DSI-6639

**Changes:**

-  reverted healthcheck library version to v3.0.0