### PR TITLE
[DSI-7556] Upgrade to Node version 22

### DIFF
--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -81,9 +81,9 @@ variables:
   - name: pr
     value: ${{ or(eq(parameters.pr, 'true'), contains(variables['Build.SourceBranch'],'release')) }}
   - name: northeurope
-    value: 'tran,pp,pr'
+    value: "tran,pp,pr"
   - name: westeurope
-    value: 'tran,dev,test,pp,pr'
+    value: "tran,dev,test,pp,pr"
 
 stages:
   # Code Scans & Build the artifact for deployment
@@ -111,69 +111,69 @@ stages:
                     - pp
                 - ${{ if eq(variables.pr, 'true') }}:
                     - pr
-              pm2ProcessFileName: process.json 
-              nodeVersionSpec: "18.17.0"
+              pm2ProcessFileName: process.json
+              nodeVersionSpec: "22.11.0"
               useRevisedLinting: true
 
-  - ${{ each location in parameters.location }}:           
-    - ${{each env in split(variables[location],',') }}:
-      - ${{ if eq(variables[env], 'true') }}:
-        - stage: Deployment_${{env}}_${{location}}
-          displayName: "Deployment [${{env}}] ${{location}}"
-          ${{ if eq(location,'westeurope') }}:
-            dependsOn:
-              - scanBuildApp
-            condition: in(dependencies.scanBuildApp.result, 'Succeeded', 'Skipped')
-          ${{ if eq(location,'northeurope') }}:
-            ${{ if eq(length(parameters.location), 2) }}:
-              dependsOn:
-                - scanBuildApp
-                - Deployment_${{env}}_westeurope
-              condition: in(dependencies.scanBuildApp.result, 'Succeeded', 'Skipped')
-            ${{ else }}:
-              dependsOn:
-                - scanBuildApp
-              condition: in(dependencies.scanBuildApp.result, 'Succeeded', 'Skipped')
-          variables:
-            - name: secRegionId
-              value: $(${{ format('{0}{1}', location, 'Id') }})
-            - name: environmentId
-              value: $[variables['${{env}}EnvId']]
-            - name: ServConName
-              value: ${{ format('{0}{1}', env, 'ServCon') }}
-            - name: ShaCodeName
-              value: ${{ format('{0}{1}', env, 'ShaCode') }}
-          jobs:
-            - template: pipeline/deployment.yml@devopsTemplates
-              parameters:
-                serviceConnection: $(${{variables.ServConName}})
-                # shaPool: $[variables['${{env}}ShaPool']]
-                # shaCode: $(${{variables.ShaCodeName}})
-                devOpsEnv: ${{variables.secRegionId}}${{env}}
-                environmentName: ${{env}}
-                applicationShortName: ${{variables.applicationShortName}}
-                applicationFullName: ${{variables.applicationFullName}}
-                releaseArtifactName: ${{variables.applicationShortName}}-${{env}}-$(Build.BuildId)-release
-                InfrDeploy: ${{parameters.InfrDeploy}}
-                deploymentLocation: ${{location}}
-                runtimeStack: NODE|18-lts
-                pm2ProcessFileName: process.json
-                gitCheck: ${{parameters.gitCheck}}
+  - ${{ each location in parameters.location }}:
+      - ${{each env in split(variables[location],',') }}:
+          - ${{ if eq(variables[env], 'true') }}:
+              - stage: Deployment_${{env}}_${{location}}
+                displayName: "Deployment [${{env}}] ${{location}}"
+                ${{ if eq(location,'westeurope') }}:
+                  dependsOn:
+                    - scanBuildApp
+                  condition: in(dependencies.scanBuildApp.result, 'Succeeded', 'Skipped')
+                ${{ if eq(location,'northeurope') }}:
+                  ${{ if eq(length(parameters.location), 2) }}:
+                    dependsOn:
+                      - scanBuildApp
+                      - Deployment_${{env}}_westeurope
+                    condition: in(dependencies.scanBuildApp.result, 'Succeeded', 'Skipped')
+                  ${{ else }}:
+                    dependsOn:
+                      - scanBuildApp
+                    condition: in(dependencies.scanBuildApp.result, 'Succeeded', 'Skipped')
+                variables:
+                  - name: secRegionId
+                    value: $(${{ format('{0}{1}', location, 'Id') }})
+                  - name: environmentId
+                    value: $[variables['${{env}}EnvId']]
+                  - name: ServConName
+                    value: ${{ format('{0}{1}', env, 'ServCon') }}
+                  - name: ShaCodeName
+                    value: ${{ format('{0}{1}', env, 'ShaCode') }}
+                jobs:
+                  - template: pipeline/deployment.yml@devopsTemplates
+                    parameters:
+                      serviceConnection: $(${{variables.ServConName}})
+                      # shaPool: $[variables['${{env}}ShaPool']]
+                      # shaCode: $(${{variables.ShaCodeName}})
+                      devOpsEnv: ${{variables.secRegionId}}${{env}}
+                      environmentName: ${{env}}
+                      applicationShortName: ${{variables.applicationShortName}}
+                      applicationFullName: ${{variables.applicationFullName}}
+                      releaseArtifactName: ${{variables.applicationShortName}}-${{env}}-$(Build.BuildId)-release
+                      InfrDeploy: ${{parameters.InfrDeploy}}
+                      deploymentLocation: ${{location}}
+                      runtimeStack: NODE|22-lts
+                      pm2ProcessFileName: process.json
+                      gitCheck: ${{parameters.gitCheck}}
 
-        - ${{ if and(eq(env, 'pp'),eq(location, 'westeurope')) }}:
-            - stage: releasebranch
-              displayName: "GitHub Release Branch Creation"
-              dependsOn:
-                - Deployment_${{env}}_${{location}}
-              jobs:
-                - template: pipeline/releaseCreation.yml@devopsTemplates
+              - ${{ if and(eq(env, 'pp'),eq(location, 'westeurope')) }}:
+                  - stage: releasebranch
+                    displayName: "GitHub Release Branch Creation"
+                    dependsOn:
+                      - Deployment_${{env}}_${{location}}
+                    jobs:
+                      - template: pipeline/releaseCreation.yml@devopsTemplates
 
-        - ${{ if and(eq(env, 'pr'),eq(location, 'westeurope')) }}:
-            - stage: branchPrTag
-              displayName: "GitHub PR & Release Branch Tag"
-              dependsOn:
-                - Deployment_${{env}}_${{location}}
-              jobs:
-                - template: pipeline/tagCreation.yml@devopsTemplates
-                  parameters:
-                    applicationName: ${{variables.applicationFullName}}
+              - ${{ if and(eq(env, 'pr'),eq(location, 'westeurope')) }}:
+                  - stage: branchPrTag
+                    displayName: "GitHub PR & Release Branch Tag"
+                    dependsOn:
+                      - Deployment_${{env}}_${{location}}
+                    jobs:
+                      - template: pipeline/tagCreation.yml@devopsTemplates
+                        parameters:
+                          applicationName: ${{variables.applicationFullName}}

--- a/DevOps/templates/template.json
+++ b/DevOps/templates/template.json
@@ -38,7 +38,7 @@
     },
     "nodeVersion": {
       "type": "string",
-      "defaultValue": "NODE|14-lts",
+      "defaultValue": "NODE|22-lts",
       "metadata": {
         "description": "The default NodeJS version that the App Service will run"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,22 +21,22 @@
         "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v3.0.2",
         "login.dfe.jobs-client": "github:DFE-Digital/login.dfe.jobs-client#v6.1.0",
         "login.dfe.winston-appinsights": "github:DFE-Digital/login.dfe.winston-appinsights#v5.0.3",
-        "sequelize": "^6.37.1",
+        "sequelize": "^6.37.6",
         "tedious": "^18.6.1",
         "uuid": "^10.0.0",
-        "winston": "^3.15.0"
+        "winston": "^3.17.0"
       },
       "devDependencies": {
-        "@eslint/js": "^9.16.0",
-        "eslint": "^9.16.0",
+        "@eslint/js": "^9.22.0",
+        "eslint": "^9.22.0",
         "eslint-formatter-junit": "^8.40.0",
-        "eslint-plugin-jest": "^28.9.0",
-        "globals": "^15.13.0",
+        "eslint-plugin-jest": "^28.11.0",
+        "globals": "^15.15.0",
         "husky": "^9.1.7",
         "jest": "^29.7.0",
         "jest-junit": "^16.0.0",
-        "lint-staged": "^15.2.10",
-        "prettier": "^3.4.2"
+        "lint-staged": "^15.5.0",
+        "prettier": "^3.5.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1124,13 +1124,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.19.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/config-array/-/config-array-0.19.1.tgz",
-      "integrity": "sha1-c0quosQL4iu7HyqdrGh8V6akyYQ=",
+      "version": "0.19.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/config-array/-/config-array-0.19.2.tgz",
+      "integrity": "sha1-MGC4CeERq/yXrbC7EXJ3i5DLRqo=",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.5",
+        "@eslint/object-schema": "^2.1.6",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
@@ -1138,10 +1138,20 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/config-helpers/-/config-helpers-0.1.0.tgz",
+      "integrity": "sha1-YvG3gh6dnO0bP1Esfqcxgldl0cw=",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@eslint/core": {
-      "version": "0.9.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/core/-/core-0.9.1.tgz",
-      "integrity": "sha1-MXY4RzCO9rcISkUFVzrJQCxR+dE=",
+      "version": "0.12.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/core/-/core-0.12.0.tgz",
+      "integrity": "sha1-X5YMPVdyi+n2xlvYSqaqYTB4eY4=",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1152,9 +1162,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
-      "integrity": "sha1-V0cKxOLig6a/dgRNYygRluNwVCw=",
+      "version": "3.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/eslintrc/-/eslintrc-3.3.0.tgz",
+      "integrity": "sha1-lqVY9FhCmJzKfqHs14WtVJEZOEY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1189,9 +1199,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.16.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/js/-/js-9.16.0.tgz",
-      "integrity": "sha1-PfKy3TuRYwVmFohshuQIL0Xb8/Q=",
+      "version": "9.22.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/js/-/js-9.22.0.tgz",
+      "integrity": "sha1-T/U2Sd7Xy86QtES0lMI0E3+hqj0=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1199,9 +1209,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/object-schema/-/object-schema-2.1.5.tgz",
-      "integrity": "sha1-hnCo9iWKK+WyxiD/MUodmEwj6y4=",
+      "version": "2.1.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha1-WDaatbWzyhF4gMD2wLDzL2lQ8k8=",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1209,12 +1219,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/plugin-kit/-/plugin-kit-0.2.4.tgz",
-      "integrity": "sha1-K3jnuzdVeEuxP6qJMqHZlNZTd5I=",
+      "version": "0.2.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
+      "integrity": "sha1-mQHVLBNvuPN1kGpz3MOCZGw7aic=",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@eslint/core": "^0.12.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -1274,9 +1285,9 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@humanwhocodes/retry/-/retry-0.4.1.tgz",
-      "integrity": "sha1-mpbOUBvGLfRsQDH72XDjzGsQ8Hs=",
+      "version": "0.4.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@humanwhocodes/retry/-/retry-0.4.2.tgz",
+      "integrity": "sha1-GGBHPeffoVRnZ0SPMz24DLD/IWE=",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3318,9 +3329,9 @@
       }
     },
     "node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha1-AUI7NvUBJZ/arE0OTWDJbJkVhdM=",
+      "version": "13.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha1-d2Fn22jHjzjczh+bjXuLmkiKv0Y=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3419,10 +3430,11 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cross-spawn/-/cross-spawn-7.0.5.tgz",
-      "integrity": "sha1-kQqsiA/1JD2pa3KLxlIaX2wvL4I=",
+      "version": "7.0.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -3433,9 +3445,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha1-h5RbQVGgEddtlaGY1xEchlw2ClI=",
+      "version": "4.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3761,30 +3773,31 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.16.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint/-/eslint-9.16.0.tgz",
-      "integrity": "sha1-ZoMuZiWJIqwKYm+AOpJz43dH8qY=",
+      "version": "9.22.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint/-/eslint-9.22.0.tgz",
+      "integrity": "sha1-B2AEOAn7+Db1ghQDRSM5hNYTxVI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.0",
-        "@eslint/core": "^0.9.0",
-        "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.16.0",
-        "@eslint/plugin-kit": "^0.2.3",
+        "@eslint/config-array": "^0.19.2",
+        "@eslint/config-helpers": "^0.1.0",
+        "@eslint/core": "^0.12.0",
+        "@eslint/eslintrc": "^3.3.0",
+        "@eslint/js": "9.22.0",
+        "@eslint/plugin-kit": "^0.2.7",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.1",
+        "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.5",
+        "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.2.0",
+        "eslint-scope": "^8.3.0",
         "eslint-visitor-keys": "^4.2.0",
         "espree": "^10.3.0",
         "esquery": "^1.5.0",
@@ -3831,9 +3844,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "28.9.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-plugin-jest/-/eslint-plugin-jest-28.9.0.tgz",
-      "integrity": "sha1-GRaN+u0SQznNIlLExNGsNoiuskM=",
+      "version": "28.11.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-plugin-jest/-/eslint-plugin-jest-28.11.0.tgz",
+      "integrity": "sha1-JkHstEEZQbvds9fPio/xFj+7UQ4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3857,9 +3870,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-scope/-/eslint-scope-8.2.0.tgz",
-      "integrity": "sha1-N3qm8ctdx1ks/Qt/iS/QzzUs5EI=",
+      "version": "8.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-scope/-/eslint-scope-8.3.0.tgz",
+      "integrity": "sha1-EM06kY/91yL18/e1uD25sjyHNA0=",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -4539,9 +4552,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "15.13.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/globals/-/globals-15.13.0.tgz",
-      "integrity": "sha1-u+xxnWmq/vGI7NZ5VKrnamlgEPw=",
+      "version": "15.15.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha1-fEdhKZ1BwysHVxWkzh7eeJf/cqg=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4778,9 +4791,9 @@
       }
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha1-NxYsJfy566oublPVtNiM4X2eDCs=",
+      "version": "3.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha1-nOy1ZQPAraHydB271lRuSxO1fM8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6007,22 +6020,22 @@
       "license": "MIT"
     },
     "node_modules/lint-staged": {
-      "version": "15.2.10",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lint-staged/-/lint-staged-15.2.10.tgz",
-      "integrity": "sha1-kqwiL4ArqRGJfc8jZx2lu4BkPNI=",
+      "version": "15.5.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lint-staged/-/lint-staged-15.5.0.tgz",
+      "integrity": "sha1-+mRkz7BuD69bsWf4MYbpUv9uVp4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "~5.3.0",
-        "commander": "~12.1.0",
-        "debug": "~4.3.6",
-        "execa": "~8.0.1",
-        "lilconfig": "~3.1.2",
-        "listr2": "~8.2.4",
-        "micromatch": "~4.0.8",
-        "pidtree": "~0.6.0",
-        "string-argv": "~0.3.2",
-        "yaml": "~2.5.0"
+        "chalk": "^5.4.1",
+        "commander": "^13.1.0",
+        "debug": "^4.4.0",
+        "execa": "^8.0.1",
+        "lilconfig": "^3.1.3",
+        "listr2": "^8.2.5",
+        "micromatch": "^4.0.8",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.7.0"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
@@ -6035,9 +6048,9 @@
       }
     },
     "node_modules/lint-staged/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha1-Z8IKfr73Dn85cKAfkPohDLaGA4U=",
+      "version": "5.4.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha1-G0i/CWPsFY3OKqz2nAk64t0gktg=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6538,9 +6551,9 @@
       }
     },
     "node_modules/logform": {
-      "version": "2.6.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/logform/-/logform-2.6.0.tgz",
-      "integrity": "sha1-jIKpg/Bdbq6y11497K56dosr+bU=",
+      "version": "2.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha1-z8qXUo7ykPLhJaCDloBQArLQYNE=",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "1.6.0",
@@ -7607,9 +7620,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.4.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/prettier/-/prettier-3.4.2.tgz",
-      "integrity": "sha1-pc4ftSKliL8reMpExub+WqWisT8=",
+      "version": "3.5.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha1-T8LODWV+egLmAlSfBTsjnLff4bU=",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -8112,9 +8125,9 @@
       }
     },
     "node_modules/sequelize": {
-      "version": "6.37.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sequelize/-/sequelize-6.37.3.tgz",
-      "integrity": "sha1-7WISAppSxZoYY40qcD2oS8L4ExE=",
+      "version": "6.37.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sequelize/-/sequelize-6.37.6.tgz",
+      "integrity": "sha1-zrLMSxk91BH2hGwetUqmHpxqz14=",
       "funding": [
         {
           "type": "opencollective",
@@ -8950,34 +8963,35 @@
       }
     },
     "node_modules/winston": {
-      "version": "3.15.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/winston/-/winston-3.15.0.tgz",
-      "integrity": "sha1-Tfe3C+CRvBo4pPRblp+nlYm3P/U=",
+      "version": "3.17.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/winston/-/winston-3.17.0.tgz",
+      "integrity": "sha1-dLhmXOm06nsp0JIs/M+FKgihFCM=",
+      "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",
-        "logform": "^2.6.0",
+        "logform": "^2.7.0",
         "one-time": "^1.0.0",
         "readable-stream": "^3.4.0",
         "safe-stable-stringify": "^2.3.1",
         "stack-trace": "0.0.x",
         "triple-beam": "^1.3.0",
-        "winston-transport": "^4.7.0"
+        "winston-transport": "^4.9.0"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/winston-transport": {
-      "version": "4.7.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/winston-transport/-/winston-transport-4.7.0.tgz",
-      "integrity": "sha1-4wLmiJ5sy384O5Jt9pNqW3gb0fA=",
+      "version": "4.9.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha1-O7o0XeECl2VOpvM1GUJFYAA7O/k=",
       "license": "MIT",
       "dependencies": {
-        "logform": "^2.3.2",
-        "readable-stream": "^3.6.0",
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
         "triple-beam": "^1.3.0"
       },
       "engines": {
@@ -9104,9 +9118,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.5.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yaml/-/yaml-2.5.1.tgz",
-      "integrity": "sha1-yXcqrPYst0lKlbDE8fsGW1Y9sTA=",
+      "version": "2.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha1-rvm7YXpkyTepp0iAN4atjT/+Hpg=",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -452,13 +452,14 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.24.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/code-frame/-/code-frame-7.24.2.tgz",
-      "integrity": "sha1-cYtLGYQYCaWLKbaM3oC8Xhqm2a4=",
+      "version": "7.26.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha1-S1+rl9MzOO/5FiNQVfDrwh5XOoU=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.24.2",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -666,9 +667,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
-      "integrity": "sha1-+Zw201k9uVQHBdBzmh8QteIMaW4=",
+      "version": "7.25.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha1-Gqu3Lucu01eJtLvK08ooYs5hTow=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -676,9 +677,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
-      "integrity": "sha1-kYsaf6IwVmA1BjcAib2ZDYcg22I=",
+      "version": "7.25.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha1-JLZOLD7HzTs8VHcpuNFocfIsvcc=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -696,120 +697,28 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.24.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helpers/-/helpers-7.24.5.tgz",
-      "integrity": "sha1-/t64fur6YrYhFgQCGBrYWFoipAo=",
+      "version": "7.26.10",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helpers/-/helpers-7.26.10.tgz",
+      "integrity": "sha1-a66jzWLsLQwQaHeNY8sTFPZjc4Q=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.24.0",
-        "@babel/traverse": "^7.24.5",
-        "@babel/types": "^7.24.5"
+        "@babel/template": "^7.26.9",
+        "@babel/types": "^7.26.10"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.24.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/highlight/-/highlight-7.24.5.tgz",
-      "integrity": "sha1-vAYT+Y4d0HIOmbKp7jdgGUpwS24=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.5",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.24.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/parser/-/parser-7.24.5.tgz",
-      "integrity": "sha1-Sk1atDFVeeU5ioLc9jbKgMM5J5A=",
+      "version": "7.26.10",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/parser/-/parser-7.26.10.tgz",
+      "integrity": "sha1-6b24LxS5ffZWmwsDjt1DaDnFd0k=",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.26.10"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1009,15 +918,15 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.24.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/template/-/template-7.24.0.tgz",
-      "integrity": "sha1-xqUkqpOkoF1mqvMWVCWPrmnYfVA=",
+      "version": "7.26.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/template/-/template-7.26.9.tgz",
+      "integrity": "sha1-RXetPd9D0ZRSjP9OH6ayMvpgm7I=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.23.5",
-        "@babel/parser": "^7.24.0",
-        "@babel/types": "^7.24.0"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.26.9",
+        "@babel/types": "^7.26.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1056,15 +965,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.24.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/types/-/types-7.24.5.tgz",
-      "integrity": "sha1-dmGTCvxjilOD6wxK7lm3TzjbhNc=",
+      "version": "7.26.10",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/types/-/types-7.26.10.tgz",
+      "integrity": "sha1-OWOC9jNb1P62V0Hqz8gIIY+Fklk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.1",
-        "@babel/helper-validator-identifier": "^7.24.5",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8666,16 +8574,6 @@
       "integrity": "sha1-hoPguQK7nCDE9ybjwLafNlGMB8w=",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "login.dfe.api.auth": "github:DFE-Digital/login.dfe.api.auth#v2.3.3",
         "login.dfe.audit.transporter": "^4.0.2",
         "login.dfe.config.schema.common": "github:DFE-Digital/login.dfe.config.schema.common#v2.1.6",
-        "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.1",
+        "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.2",
         "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v3.0.2",
         "login.dfe.jobs-client": "github:DFE-Digital/login.dfe.jobs-client#v6.1.0",
         "login.dfe.winston-appinsights": "github:DFE-Digital/login.dfe.winston-appinsights#v5.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,9 +37,6 @@
         "jest-junit": "^16.0.0",
         "lint-staged": "^15.2.10",
         "prettier": "^3.4.2"
-      },
-      "engines": {
-        "node": "18.x.x"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
   "name": "login.dfe.access",
   "version": "6.0.0",
-  "engines": {
-    "node": "18.x.x"
-  },
   "description": "Provides resource access functionality to platform components.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "login.dfe.api.auth": "github:DFE-Digital/login.dfe.api.auth#v2.3.3",
     "login.dfe.audit.transporter": "^4.0.2",
     "login.dfe.config.schema.common": "github:DFE-Digital/login.dfe.config.schema.common#v2.1.6",
-    "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.1",
+    "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.2",
     "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v3.0.2",
     "login.dfe.jobs-client": "github:DFE-Digital/login.dfe.jobs-client#v6.1.0",
     "login.dfe.winston-appinsights": "github:DFE-Digital/login.dfe.winston-appinsights#v5.0.3",

--- a/package.json
+++ b/package.json
@@ -37,22 +37,22 @@
     "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v3.0.2",
     "login.dfe.jobs-client": "github:DFE-Digital/login.dfe.jobs-client#v6.1.0",
     "login.dfe.winston-appinsights": "github:DFE-Digital/login.dfe.winston-appinsights#v5.0.3",
-    "sequelize": "^6.37.1",
+    "sequelize": "^6.37.6",
     "tedious": "^18.6.1",
     "uuid": "^10.0.0",
-    "winston": "^3.15.0"
+    "winston": "^3.17.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.16.0",
-    "eslint": "^9.16.0",
+    "@eslint/js": "^9.22.0",
+    "eslint": "^9.22.0",
     "eslint-formatter-junit": "^8.40.0",
-    "eslint-plugin-jest": "^28.9.0",
-    "globals": "^15.13.0",
+    "eslint-plugin-jest": "^28.11.0",
+    "globals": "^15.15.0",
     "husky": "^9.1.7",
     "jest": "^29.7.0",
     "jest-junit": "^16.0.0",
-    "lint-staged": "^15.2.10",
-    "prettier": "^3.4.2"
+    "lint-staged": "^15.5.0",
+    "prettier": "^3.5.3"
   },
   "jest": {
     "testEnvironment": "node",

--- a/src/infrastructure/data/organisationsRepository/connection.js
+++ b/src/infrastructure/data/organisationsRepository/connection.js
@@ -2,8 +2,6 @@ const Sequelize = require("sequelize").default;
 const assert = require("assert");
 const config = require("./../../config");
 
-const Op = Sequelize.Op;
-
 const getIntValueOrDefault = (value, defaultValue = 0) => {
   if (!value) {
     return defaultValue;
@@ -52,7 +50,6 @@ const makeConnection = () => {
     },
     host: config.database.host,
     dialect: config.database.dialect,
-    operatorsAliases: Op,
     dialectOptions: {
       encrypt: encryptDb,
     },


### PR DESCRIPTION
### Summary
Jira ticket: https://dfe-secureaccess.atlassian.net/browse/DSI-7556

### Changes
- Update pipeline related files for Node 22, specifically 22.11.0
- Updated to use the latest DfE components
- Updated some of the 3rd party packages where deemed safe
- Remove deprecated `operatorsAliases` param from Sequelize DB Options
- Fix 1 moderate vulnerability