### PR TITLE
NSA-9313: Increase role name limit from 125 to 250 in access service

### DIFF
--- a/src/app/services/createRoleOfService.js
+++ b/src/app/services/createRoleOfService.js
@@ -15,10 +15,10 @@ const createRoleOfService = async (req, res) => {
     return res.status(400).send({ error: "Application ID must be a uuid" });
   }
 
-  if (roleName.length > 125) {
+  if (roleName.length > 250) {
     return res
       .status(400)
-      .send({ error: "Role name must be 125 characters or less" });
+      .send({ error: "Role name must be 250 characters or less" });
   }
 
   if (roleCode.length > 50) {

--- a/src/app/services/updateRoleOfService.js
+++ b/src/app/services/updateRoleOfService.js
@@ -21,8 +21,8 @@ const validate = (req, serviceRoles) => {
       const name = req.body.name;
       if (!name || typeof name !== "string") {
         errors.push("'name' must be a non-empty string");
-      } else if (name.length > 125) {
-        errors.push("'name' cannot be greater than 125 characters");
+      } else if (name.length > 250) {
+        errors.push("'name' cannot be greater than 250 characters");
       }
     }
     if (key === "code") {

--- a/test/app/services/createRoleOfService.test.js
+++ b/test/app/services/createRoleOfService.test.js
@@ -110,15 +110,15 @@ describe("When creating a role of a service", () => {
     });
   });
 
-  it("should return 400 if roleName exceeds 125 characters", async () => {
-    req.body.roleName = "a".repeat(126);
+  it("should return 400 if roleName exceeds 250 characters", async () => {
+    req.body.roleName = "a".repeat(251);
     validate.mockReturnValue(true);
 
     await createRoleOfService(req, res);
 
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.send).toHaveBeenCalledWith({
-      error: "Role name must be 125 characters or less",
+      error: "Role name must be 250 characters or less",
     });
   });
 

--- a/test/app/services/updateRole.test.js
+++ b/test/app/services/updateRole.test.js
@@ -107,8 +107,8 @@ describe("When patching a role of a service", () => {
     });
   });
 
-  it("should return 400 if name is greater than 125 characters", async () => {
-    req.body.name = "abcde12345".repeat(12) + "abcdef"; // 126 characters
+  it("should return 400 if name is greater than 250 characters", async () => {
+    req.body.name = "abcde12345".repeat(25) + "a"; // 251 characters
 
     await updateRoleOfService(req, res);
 
@@ -116,7 +116,7 @@ describe("When patching a role of a service", () => {
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.send).toHaveBeenCalledTimes(1);
     expect(res.send).toHaveBeenCalledWith({
-      errors: ["'name' cannot be greater than 125 characters"],
+      errors: ["'name' cannot be greater than 250 characters"],
     });
   });
 


### PR DESCRIPTION
## Summary
- Increases role name validation from 125 to 250 characters in `createRoleOfService` and `updateRoleOfService`
- Fixes 400 errors thrown when a role name between 126–250 characters was submitted via the Manage console
- Companion to login.dfe.manage PR #361 and login.dfe.db-scripts PR #2469

## Why
The `login.dfe.access` API was rejecting role names > 125 chars with a 400, even after the app-side validation in `login.dfe.manage` was updated to allow up to 250. This was discovered during deployment to dev/test.

## Test plan
- [x] POST `/services/{id}/roles` with a role name of 126–250 characters — should return 201
- [ ] POST `/services/{id}/roles` with a role name of 251+ characters — should return 400 with "Role name must be 250 characters or less"
- [ ] PATCH `/services/{id}/roles/{rid}` with a name of 126–250 characters — should return 202
- [ ] PATCH `/services/{id}/roles/{rid}` with a name of 251+ characters — should return 400 with "'name' cannot be greater than 250 characters"