### PR TITLE
NSA-9314: Pass removed service and org IDs through notification payload

### DIFF
--- a/src/app/users/removeServiceFromUser.js
+++ b/src/app/users/removeServiceFromUser.js
@@ -38,7 +38,7 @@ const removeServiceFromUser = async (req, res) => {
     await removeAllUserServiceIdentifiers(uid, sid, oid);
     await removeUserService(uid, sid, oid);
 
-    await notifyUserUpdated(uid);
+    await notifyUserUpdated(uid, sid, oid);
 
     return res.status(204).send();
   } catch (e) {

--- a/src/infrastructure/notifications/index.js
+++ b/src/infrastructure/notifications/index.js
@@ -5,11 +5,13 @@ const serviceNotificationsClient = new ServiceNotificationsClient(
   config.notifications,
 );
 
-const notifyUserUpdated = async (userId) => {
-  const notificationsEnabled =
-    config.toggles && config.toggles.notificationsEnabled === true;
-  if (notificationsEnabled) {
-    await serviceNotificationsClient.notifyUserUpdated({ sub: userId });
+const notifyUserUpdated = async (userId, serviceId, orgId) => {
+  if (config.toggles && config.toggles.notificationsEnabled === true) {
+    await serviceNotificationsClient.notifyUserUpdated({
+      sub: userId,
+      ...(serviceId && { removedServiceId: serviceId }),
+      ...(orgId && { removedOrgId: orgId }),
+    });
   }
 };
 

--- a/test/app/users/removeServiceFromUser.test.js
+++ b/test/app/users/removeServiceFromUser.test.js
@@ -76,11 +76,11 @@ describe("When removing service from user", () => {
     expect(res.send).toHaveBeenCalledTimes(1);
   });
 
-  it("then it should send notification of user update", async () => {
+  it("then it should send notification of user update with uid, sid, and oid", async () => {
     await removeServiceFromUser(req, res);
 
     expect(notifyUserUpdated).toHaveBeenCalledTimes(1);
-    expect(notifyUserUpdated).toHaveBeenCalledWith(uid);
+    expect(notifyUserUpdated).toHaveBeenCalledWith(uid, sid, oid);
   });
 
   it("should raise an exception if an exception is raised in removeUserService", async () => {

--- a/test/infrastructure/notifications/index.notifyUserUpdated.test.js
+++ b/test/infrastructure/notifications/index.notifyUserUpdated.test.js
@@ -1,0 +1,65 @@
+const mockNotifyUserUpdatedFn = jest.fn();
+
+jest.mock("login.dfe.jobs-client", () => ({
+  ServiceNotificationsClient: jest.fn().mockImplementation(() => ({
+    notifyUserUpdated: mockNotifyUserUpdatedFn,
+  })),
+}));
+
+jest.mock("./../../../src/infrastructure/config", () => ({
+  notifications: {},
+  toggles: { notificationsEnabled: true },
+}));
+
+const {
+  notifyUserUpdated,
+} = require("./../../../src/infrastructure/notifications");
+const config = require("./../../../src/infrastructure/config");
+
+describe("notifyUserUpdated", () => {
+  beforeEach(() => {
+    mockNotifyUserUpdatedFn.mockReset();
+    config.toggles.notificationsEnabled = true;
+  });
+
+  it("forwards removedServiceId and removedOrgId when both are provided", async () => {
+    await notifyUserUpdated("user-123", "service-456", "org-789");
+
+    expect(mockNotifyUserUpdatedFn).toHaveBeenCalledTimes(1);
+    expect(mockNotifyUserUpdatedFn).toHaveBeenCalledWith({
+      sub: "user-123",
+      removedServiceId: "service-456",
+      removedOrgId: "org-789",
+    });
+  });
+
+  it("sends only sub when called with one argument (backward compatibility)", async () => {
+    await notifyUserUpdated("user-123");
+
+    expect(mockNotifyUserUpdatedFn).toHaveBeenCalledTimes(1);
+    const callArg = mockNotifyUserUpdatedFn.mock.calls[0][0];
+    expect(callArg).toEqual({ sub: "user-123" });
+    expect(callArg).not.toHaveProperty("removedServiceId");
+    expect(callArg).not.toHaveProperty("removedOrgId");
+  });
+
+  it("handles partial arguments correctly", async () => {
+    await notifyUserUpdated("user-123", "service-456");
+
+    expect(mockNotifyUserUpdatedFn).toHaveBeenCalledTimes(1);
+    const callArg = mockNotifyUserUpdatedFn.mock.calls[0][0];
+    expect(callArg).toEqual({
+      sub: "user-123",
+      removedServiceId: "service-456",
+    });
+    expect(callArg).not.toHaveProperty("removedOrgId");
+  });
+
+  it("does not call serviceNotificationsClient.notifyUserUpdated when notifications are disabled", async () => {
+    config.toggles.notificationsEnabled = false;
+
+    await notifyUserUpdated("user-123", "service-456", "org-789");
+
+    expect(mockNotifyUserUpdatedFn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
https://dfe-secureaccess.atlassian.net/browse/NSA-9314

When a legacy service (COLLECT/S2S) is removed from a user, no SOAP deactivation sync is sent to the downstream service because the notification payload only contains { sub: userId } - the handler in login.dfe.jobs has no way of knowing which service was removed. This PR passes the removed service and org IDs through the notification so the downstream handler can send a targeted deactivation sync.

**Changes:**
- notifications/index.js: extended notifyUserUpdated to accept optional serviceId and orgId, forwarded as removedServiceId and removedOrgId using spread guards for backward compatibility
- removeServiceFromUser.js: passes sid and oid to notifyUserUpdated

**Related:**
- login.dfe.jobs PR: NSA-9314 (consumes removedServiceId to send deactivation sync)
