### PR TITLE
Fix(NSA-9314): forward removedServiceId and removedOrgId through notifications wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ junit.xml
 /config/
 
 access.log
+.worktrees/

--- a/src/app/users/removeServiceFromUser.js
+++ b/src/app/users/removeServiceFromUser.js
@@ -38,7 +38,17 @@ const removeServiceFromUser = async (req, res) => {
     await removeAllUserServiceIdentifiers(uid, sid, oid);
     await removeUserService(uid, sid, oid);
 
-    await notifyUserUpdated(uid, sid, oid);
+    try {
+      await notifyUserUpdated(uid, sid, oid);
+    } catch (notifyError) {
+      // The access removal above has already succeeded - a WS sync
+      // notification failure here must not turn a successful removal into
+      // an error response to the caller.
+      logger.warn(
+        `Failed to notify legacy WS Sync on service removal for user ${uid}`,
+        { correlationId, error: { ...notifyError } },
+      );
+    }
 
     return res.status(204).send();
   } catch (e) {

--- a/src/app/users/removeServiceFromUser.js
+++ b/src/app/users/removeServiceFromUser.js
@@ -38,7 +38,7 @@ const removeServiceFromUser = async (req, res) => {
     await removeAllUserServiceIdentifiers(uid, sid, oid);
     await removeUserService(uid, sid, oid);
 
-    await notifyUserUpdated(uid);
+    await notifyUserUpdated(uid, sid, oid);
 
     return res.status(204).send();
   } catch (e) {

--- a/src/infrastructure/notifications/index.js
+++ b/src/infrastructure/notifications/index.js
@@ -5,11 +5,15 @@ const serviceNotificationsClient = new ServiceNotificationsClient(
   config.notifications,
 );
 
-const notifyUserUpdated = async (userId) => {
+const notifyUserUpdated = async (userId, removedServiceId, removedOrgId) => {
   const notificationsEnabled =
     config.toggles && config.toggles.notificationsEnabled === true;
   if (notificationsEnabled) {
-    await serviceNotificationsClient.notifyUserUpdated({ sub: userId });
+    await serviceNotificationsClient.notifyUserUpdated({
+      sub: userId,
+      ...(removedServiceId && { removedServiceId }),
+      ...(removedOrgId && { removedOrgId }),
+    });
   }
 };
 

--- a/test/app/users/removeServiceFromUser.test.js
+++ b/test/app/users/removeServiceFromUser.test.js
@@ -80,7 +80,7 @@ describe("When removing service from user", () => {
     await removeServiceFromUser(req, res);
 
     expect(notifyUserUpdated).toHaveBeenCalledTimes(1);
-    expect(notifyUserUpdated).toHaveBeenCalledWith(uid);
+    expect(notifyUserUpdated).toHaveBeenCalledWith(uid, sid, oid);
   });
 
   it("should raise an exception if an exception is raised in removeUserService", async () => {

--- a/test/app/users/removeServiceFromUser.test.js
+++ b/test/app/users/removeServiceFromUser.test.js
@@ -90,4 +90,16 @@ describe("When removing service from user", () => {
 
     await expect(removeServiceFromUser(req, res)).rejects.toThrow("bad times");
   });
+
+  it("should still return 204 when notifyUserUpdated fails, since the removal already succeeded", async () => {
+    notifyUserUpdated.mockImplementation(() => {
+      throw new Error("ws sync unavailable");
+    });
+
+    await removeServiceFromUser(req, res);
+
+    expect(removeUserService).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(204);
+    expect(res.send).toHaveBeenCalledTimes(1);
+  });
 });

--- a/test/infrastructure/notifications/index.test.js
+++ b/test/infrastructure/notifications/index.test.js
@@ -1,0 +1,66 @@
+jest.mock("login.dfe.jobs-client");
+jest.mock("./../../../src/infrastructure/config", () =>
+  require("./../../utils").mockConfig({
+    toggles: { notificationsEnabled: true },
+  }),
+);
+
+const { ServiceNotificationsClient } = require("login.dfe.jobs-client");
+const mockNotifyUserUpdated = jest.fn().mockResolvedValue();
+ServiceNotificationsClient.mockImplementation(() => ({
+  notifyUserUpdated: mockNotifyUserUpdated,
+}));
+
+const {
+  notifyUserUpdated,
+} = require("./../../../src/infrastructure/notifications");
+
+beforeEach(() => {
+  mockNotifyUserUpdated.mockClear();
+});
+
+describe("When notifying user updated", () => {
+  it("passes only sub when no removal IDs are supplied", async () => {
+    await notifyUserUpdated("user-1");
+    expect(mockNotifyUserUpdated).toHaveBeenCalledWith({ sub: "user-1" });
+  });
+
+  it("passes sub, removedServiceId, and removedOrgId when all three are supplied", async () => {
+    await notifyUserUpdated("user-1", "svc-1", "org-1");
+    expect(mockNotifyUserUpdated).toHaveBeenCalledWith({
+      sub: "user-1",
+      removedServiceId: "svc-1",
+      removedOrgId: "org-1",
+    });
+  });
+
+  it("passes sub and removedServiceId when only removedServiceId is supplied", async () => {
+    await notifyUserUpdated("user-1", "svc-1");
+    expect(mockNotifyUserUpdated).toHaveBeenCalledWith({
+      sub: "user-1",
+      removedServiceId: "svc-1",
+    });
+  });
+
+  it("passes sub and removedOrgId when only removedOrgId is supplied", async () => {
+    await notifyUserUpdated("user-1", undefined, "org-1");
+    expect(mockNotifyUserUpdated).toHaveBeenCalledWith({
+      sub: "user-1",
+      removedOrgId: "org-1",
+    });
+  });
+
+  it("does not call the client when notifications are disabled", async () => {
+    jest.resetModules();
+    jest.mock("./../../../src/infrastructure/config", () =>
+      require("./../../utils").mockConfig({
+        toggles: { notificationsEnabled: false },
+      }),
+    );
+    const {
+      notifyUserUpdated: fn,
+    } = require("./../../../src/infrastructure/notifications");
+    await fn("user-1", "svc-1", "org-1");
+    expect(mockNotifyUserUpdated).not.toHaveBeenCalled();
+  });
+});

--- a/test/infrastructure/notifications/index.test.js
+++ b/test/infrastructure/notifications/index.test.js
@@ -52,15 +52,24 @@ describe("When notifying user updated", () => {
 
   it("does not call the client when notifications are disabled", async () => {
     jest.resetModules();
-    jest.mock("./../../../src/infrastructure/config", () =>
+    jest.doMock("./../../../src/infrastructure/config", () =>
       require("./../../utils").mockConfig({
         toggles: { notificationsEnabled: false },
       }),
     );
+    jest.doMock("login.dfe.jobs-client");
+    const {
+      ServiceNotificationsClient: FreshServiceNotificationsClient,
+    } = require("login.dfe.jobs-client");
+    const freshMockNotifyUserUpdated = jest.fn().mockResolvedValue();
+    FreshServiceNotificationsClient.mockImplementation(() => ({
+      notifyUserUpdated: freshMockNotifyUserUpdated,
+    }));
+
     const {
       notifyUserUpdated: fn,
     } = require("./../../../src/infrastructure/notifications");
     await fn("user-1", "svc-1", "org-1");
-    expect(mockNotifyUserUpdated).not.toHaveBeenCalled();
+    expect(freshMockNotifyUserUpdated).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- `notifications/index.js`: updated `notifyUserUpdated` to accept and forward optional `removedServiceId` and `removedOrgId` (backward-compatible - existing callers unaffected)
- `removeServiceFromUser.js`: passes `sid` and `oid` through to `notifyUserUpdated`

## Dependency
Deploy `login.dfe.jobs` NSA-9314 PR first.

## Test plan
- [ ] 314 tests passing
- [ ] PP: removing a service via the Access API triggers a DEACTIVATE SOAP call
